### PR TITLE
Updated npm version and simplified deployment of global parameters

### DIFF
--- a/data-factory/devops-build-n-deploy-stages/adf-build-job.yml
+++ b/data-factory/devops-build-n-deploy-stages/adf-build-job.yml
@@ -55,9 +55,6 @@ jobs:
       customCommand: 'run build export $(workingDirectory) $(dataFactoryResourceId) "$(artifactTempDirectory)"'
     displayName: 'Validate and Generate ARM template'
 
-  - script: 'mv -v $(packageJsonFolder)$(artifactTempDirectory)/${{ parameters.dataFactoryName }}_GlobalParameters.json $(packageJsonFolder)$(artifactTempDirectory)/GlobalParameters.json'
-    displayName: 'Rename Global Parameter File post'
-
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(packageJsonFolder)$(artifactTempDirectory)'

--- a/data-factory/devops-build-n-deploy-stages/adf-deploy-job.yml
+++ b/data-factory/devops-build-n-deploy-stages/adf-deploy-job.yml
@@ -70,16 +70,6 @@ jobs:
             overrideParameters: >
               -factoryName ${{ parameters.dataFactoryName }}
               ${{ parameters.overrideParameters }}
-
-        - task: AzurePowerShell@5
-          displayName: 'Deploy Global Parameters'
-          inputs:
-            azureSubscription: '${{ parameters.serviceConnectionName }}'
-            ScriptPath: '$(artifactsDirectory)/GlobalParametersUpdateScript.ps1'
-            ScriptArguments: "-globalParametersFilePath $(artifactsDirectory)/GlobalParameters.json \
-              -resourceGroupName ${{ parameters.resourceGroupName }} \
-              -dataFactoryName ${{ parameters.dataFactoryName }}"
-            azurePowerShellVersion: LatestVersion
             
         - task: AzurePowerShell@5
           displayName: 'Start Triggers'

--- a/data-factory/devops-build-n-deploy-stages/package.json
+++ b/data-factory/devops-build-n-deploy-stages/package.json
@@ -3,6 +3,6 @@
         "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index"
     },
     "dependencies":{
-        "@microsoft/azure-data-factory-utilities":"^0.1.5"
+        "@microsoft/azure-data-factory-utilities":"^1.0.0"
     }
 } 

--- a/data-factory/devops-build-n-deploy-stages/readme.md
+++ b/data-factory/devops-build-n-deploy-stages/readme.md
@@ -8,6 +8,7 @@ Job templates for building and deploying Azure Data Factory with Azure DevOps
 1. In Azure Data Factory
     1. Setup ADF sync repo in your data factory
        - Recommended to use Root Folder path **/data-factory/** or **/data-factory/<data_factory_name>** if you have many ADFs
+    2. Make sure to check **Include global parameters in ARM template** option under **Manage >> ARM template**
 2. In Azure DevOps
     1. Create folder **/devops/** and then, in that folder create following files
         1. Create file [package.json](package.json) 
@@ -78,10 +79,7 @@ Job templates for building and deploying Azure Data Factory with Azure DevOps
                   command: 'custom'
                   workingDir: $(packageJsonFolder)
                   customCommand: 'run build export $(workingDirectory) $(dataFactoryResourceId) "$(artifactTempDirectory)"'
-                displayName: 'Validate and Generate ARM template'
-            
-              - script: 'mv -v $(packageJsonFolder)$(artifactTempDirectory)/${{ parameters.dataFactoryName }}_GlobalParameters.json $(packageJsonFolder)$(artifactTempDirectory)/GlobalParameters.json'
-                displayName: 'Rename Global Parameter File post'
+                displayName: 'Validate and Generate ARM template'        
             
               - task: PublishPipelineArtifact@1
                 inputs:
@@ -184,17 +182,7 @@ Job templates for building and deploying Azure Data Factory with Azure DevOps
                     overrideParameters: >
                       -factoryName ${{ parameters.dataFactoryName }}
                       ${{ parameters.overrideParameters }}
-        
-                - task: AzurePowerShell@5
-                  displayName: 'Deploy Global Parameters'
-                  inputs:
-                    azureSubscription: '${{ parameters.serviceConnectionName }}'
-                    ScriptPath: '$(artifactsDirectory)/GlobalParametersUpdateScript.ps1'
-                    ScriptArguments: "-globalParametersFilePath $(artifactsDirectory)/GlobalParameters.json \
-                      -resourceGroupName ${{ parameters.resourceGroupName }} \
-                      -dataFactoryName ${{ parameters.dataFactoryName }}"
-                    azurePowerShellVersion: LatestVersion
-                    
+                            
                 - task: AzurePowerShell@5
                   displayName: 'Start Triggers'
                   inputs:

--- a/data-factory/devops-build-n-deploy-stages/readme.md
+++ b/data-factory/devops-build-n-deploy-stages/readme.md
@@ -17,7 +17,7 @@ Job templates for building and deploying Azure Data Factory with Azure DevOps
                     "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index"
                 },
                 "dependencies":{
-                    "@microsoft/azure-data-factory-utilities":"^0.1.5"
+                    "@microsoft/azure-data-factory-utilities":"^1.0.0"
                 }
             } 
             ```


### PR DESCRIPTION
I made two changes:

1. Updated version of **@microsoft/azure-data-factory-utilities** from **^0.1.5** to **^1.0.0** as that's the newest version: https://learn.microsoft.com/en-us/azure/data-factory/continuous-integration-delivery-improvements#create-an-azure-pipeline
2. Simplified deployment of global parameters:
    - They can now be included in the ARM template (requires checking one option in ADF).
    - It means that no longer we have to bother with copying & deploying the **GlobalParameters.json** file.
    - Info in MS Learn: https://learn.microsoft.com/en-us/azure/data-factory/author-global-parameters#cicd
    - Even in the [GlobalParametersUpdateScript.ps1](https://github.com/Azure/Azure-DataFactory/blob/main/SamplesV2/ContinuousIntegrationAndDelivery/GlobalParametersUpdateScript.ps1) (the old method) they added a warning to not use it anymore.